### PR TITLE
Add Currency Buttons

### DIFF
--- a/app/controllers/charts_controller.rb
+++ b/app/controllers/charts_controller.rb
@@ -8,6 +8,8 @@ class ChartsController < ApplicationController
   private
 
   def requested_currencies
-    'EUR,USD,AUD'
+    return 'EUR,USD,AUD' if session[:currency].blank?
+
+    session[:currency]
   end
 end

--- a/app/controllers/exchange_rates_controller.rb
+++ b/app/controllers/exchange_rates_controller.rb
@@ -1,4 +1,12 @@
 # Controller for rendering main application page and requests from there.
 class ExchangeRatesController < ApplicationController
+  after_action :set_currency_cookie, only: :index
+
   def index; end
+
+  private
+
+  def set_currency_cookie
+    session[:currency] = params[:currency]
+  end
 end

--- a/app/services/rate_getter_service.rb
+++ b/app/services/rate_getter_service.rb
@@ -57,18 +57,24 @@ class RateGetterService
   # rubocop:enable Metrics/MethodLength
 
   def setup_series_data
-    [euro_series, usd_series, aud_series]
+    [euro_series, usd_series, aud_series].compact
   end
 
   def euro_series
+    return nil if euro_data.empty?
+
     { name: 'EUR', data: euro_data }
   end
 
   def usd_series
+    return nil if usd_data.empty?
+
     { name: 'USD', data: usd_data }
   end
 
   def aud_series
+    return nil if aud_data.empty?
+
     { name: 'AUD', data: aud_data }
   end
 

--- a/app/views/exchange_rates/_form.html.erb
+++ b/app/views/exchange_rates/_form.html.erb
@@ -1,0 +1,6 @@
+<form>
+  <%= button_tag 'EUR', name: 'currency', value: 'EUR' %>
+  <%= button_tag 'USD', name: 'currency', value: 'USD' %>
+  <%= button_tag 'AUD', name: 'currency', value: 'AUD' %>
+  <%= button_tag 'Reset', name: nil %>
+</form>

--- a/app/views/exchange_rates/index.html.erb
+++ b/app/views/exchange_rates/index.html.erb
@@ -1,3 +1,6 @@
 <h2>Historic Exchange Rates</h2>
 
-<%= render "line_chart" %>
+<%= render 'line_chart' %>
+
+<h3>Currencies</h3>
+<%= render 'form' %>

--- a/spec/controllers/exchange_rates_controller_spec.rb
+++ b/spec/controllers/exchange_rates_controller_spec.rb
@@ -6,5 +6,15 @@ RSpec.describe ExchangeRatesController, type: :controller do
       get :index
       expect(response).to have_http_status(:ok)
     end
+
+    it 'should set the currency for the session when the param is provided' do
+      get :index, params: { currency: 'USD' }
+      expect(session[:currency]).to eq 'USD'
+    end
+
+    it 'should not set the currency for the session when there is no param' do
+      get :index
+      expect(session[:currency]).to be_blank
+    end
   end
 end

--- a/spec/views/exchange_rates/index.html.erb_spec.rb
+++ b/spec/views/exchange_rates/index.html.erb_spec.rb
@@ -12,4 +12,10 @@ RSpec.describe 'exchange_rates/index' do
 
     expect(response).to include('historic-exchange-rates-chart')
   end
+
+  it 'should render the form for changing the charted currencies' do
+    render partial: 'exchange_rates/form.html.erb'
+
+    expect(response).to include('form')
+  end
 end


### PR DESCRIPTION
Adds a form to the exchange_rates#index that allows for changing of which currency is displayed on the line chart. Updates both controllers and service to allow the currency param to be passed into the session so that the service can use the user's requested currency when contacting the API.