### PR TITLE
Match button and currency line color

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -51,3 +51,12 @@
   background: #00008b;
   color: white;
 }
+
+.reset {
+  border-color: #e7e7e7;
+  color: black;
+}
+
+.reset:hover {
+  background: #e7e7e7;
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -41,3 +41,13 @@
   background: #bf0a30;
   color: white;
 }
+
+.aud {
+  border-color: #00008b;
+  color: #00008b
+}
+
+.aud:hover {
+  background: #00008b;
+  color: white;
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -15,20 +15,21 @@
  */
 .btn {
   border: 2px solid black;
+  border-radius: 8px;
   background-color: white;
   color: black;
-  padding: 14px 28px;
+  padding: 12px 28px;
   font-size: 16px;
   cursor: pointer;
 }
 
 .euro {
-  border-color: #fdcb0b;
-  color: #fdcb0b
+  border-color: #fdb827;
+  color: #fdb827
 }
 
 .euro:hover {
-  background: #fdcb0b;
+  background: #fdb827;
   color: white;
 }
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -22,6 +22,16 @@
   cursor: pointer;
 }
 
+.euro {
+  border-color: #fdcb0b;
+  color: #fdcb0b
+}
+
+.euro:hover {
+  background: #fdcb0b;
+  color: white;
+}
+
 .usd {
   border-color: #bf0a30;
   color: #bf0a30

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,21 @@
  *= require_tree .
  *= require_self
  */
+.btn {
+  border: 2px solid black;
+  background-color: white;
+  color: black;
+  padding: 14px 28px;
+  font-size: 16px;
+  cursor: pointer;
+}
+
+.usd {
+  border-color: #bf0a30;
+  color: #bf0a30
+}
+
+.usd:hover {
+  background: #bf0a30;
+  color: white;
+}

--- a/app/services/rate_getter_service.rb
+++ b/app/services/rate_getter_service.rb
@@ -75,7 +75,7 @@ class RateGetterService
   def aud_series
     return nil if aud_data.empty?
 
-    { name: 'AUD', data: aud_data }
+    { name: 'AUD', data: aud_data, color: ['#00008b'] }
   end
 
   def build_request_url

--- a/app/services/rate_getter_service.rb
+++ b/app/services/rate_getter_service.rb
@@ -63,7 +63,7 @@ class RateGetterService
   def euro_series
     return nil if euro_data.empty?
 
-    { name: 'EUR', data: euro_data, color: ['#fdcb0b'] }
+    { name: 'EUR', data: euro_data, color: ['#fdb827'] }
   end
 
   def usd_series

--- a/app/services/rate_getter_service.rb
+++ b/app/services/rate_getter_service.rb
@@ -63,7 +63,7 @@ class RateGetterService
   def euro_series
     return nil if euro_data.empty?
 
-    { name: 'EUR', data: euro_data }
+    { name: 'EUR', data: euro_data, color: ['#fdcb0b'] }
   end
 
   def usd_series

--- a/app/services/rate_getter_service.rb
+++ b/app/services/rate_getter_service.rb
@@ -69,7 +69,7 @@ class RateGetterService
   def usd_series
     return nil if usd_data.empty?
 
-    { name: 'USD', data: usd_data }
+    { name: 'USD', data: usd_data, color: ['#bf0a30'] }
   end
 
   def aud_series

--- a/app/views/exchange_rates/_form.html.erb
+++ b/app/views/exchange_rates/_form.html.erb
@@ -3,4 +3,5 @@
   <%= button_tag 'USD', name: 'currency', value: 'USD' %>
   <%= button_tag 'AUD', name: 'currency', value: 'AUD' %>
   <%= button_tag 'Reset', name: nil %>
+  <%= button_tag 'USD', name: 'currency', value: 'USD', class: "btn usd" %>
 </form>

--- a/app/views/exchange_rates/_form.html.erb
+++ b/app/views/exchange_rates/_form.html.erb
@@ -1,9 +1,6 @@
 <form>
-  <%= button_tag 'EUR', name: 'currency', value: 'EUR' %>
-  <%= button_tag 'USD', name: 'currency', value: 'USD' %>
-  <%= button_tag 'AUD', name: 'currency', value: 'AUD' %>
-  <%= button_tag 'Reset', name: nil %>
   <%= button_tag 'EUR', name: 'currency', value: 'EUR', class: "btn euro" %>
   <%= button_tag 'USD', name: 'currency', value: 'USD', class: "btn usd" %>
   <%= button_tag 'AUD', name: 'currency', value: 'AUD', class: "btn aud" %>
+  <%= button_tag 'Reset', name: nil, class: "btn reset" %>
 </form>

--- a/app/views/exchange_rates/_form.html.erb
+++ b/app/views/exchange_rates/_form.html.erb
@@ -3,5 +3,6 @@
   <%= button_tag 'USD', name: 'currency', value: 'USD' %>
   <%= button_tag 'AUD', name: 'currency', value: 'AUD' %>
   <%= button_tag 'Reset', name: nil %>
+  <%= button_tag 'EUR', name: 'currency', value: 'EUR', class: "btn euro" %>
   <%= button_tag 'USD', name: 'currency', value: 'USD', class: "btn usd" %>
 </form>

--- a/app/views/exchange_rates/_form.html.erb
+++ b/app/views/exchange_rates/_form.html.erb
@@ -5,4 +5,5 @@
   <%= button_tag 'Reset', name: nil %>
   <%= button_tag 'EUR', name: 'currency', value: 'EUR', class: "btn euro" %>
   <%= button_tag 'USD', name: 'currency', value: 'USD', class: "btn usd" %>
+  <%= button_tag 'AUD', name: 'currency', value: 'AUD', class: "btn aud" %>
 </form>

--- a/spec/services/rate_getter_service_spec.rb
+++ b/spec/services/rate_getter_service_spec.rb
@@ -113,6 +113,7 @@ RSpec.describe RateGetterService, type: :service do
 
           expect(usd_series[:name]).to eq 'USD'
           expect(usd_series[:data]).to eq service.usd_data
+          expect(usd_series[:color]).to eq ['#bf0a30']
         end
       end
 

--- a/spec/services/rate_getter_service_spec.rb
+++ b/spec/services/rate_getter_service_spec.rb
@@ -95,6 +95,7 @@ RSpec.describe RateGetterService, type: :service do
 
           expect(euro_series[:name]).to eq 'EUR'
           expect(euro_series[:data]).to eq service.euro_data
+          expect(euro_series[:color]).to eq ['#fdcb0b']
         end
       end
 

--- a/spec/services/rate_getter_service_spec.rb
+++ b/spec/services/rate_getter_service_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe RateGetterService, type: :service do
 
           expect(euro_series[:name]).to eq 'EUR'
           expect(euro_series[:data]).to eq service.euro_data
-          expect(euro_series[:color]).to eq ['#fdcb0b']
+          expect(euro_series[:color]).to eq ['#fdb827']
         end
       end
 

--- a/spec/services/rate_getter_service_spec.rb
+++ b/spec/services/rate_getter_service_spec.rb
@@ -133,6 +133,7 @@ RSpec.describe RateGetterService, type: :service do
 
           expect(aud_series[:name]).to eq 'AUD'
           expect(aud_series[:data]).to eq service.aud_data
+          expect(aud_series[:color]).to eq ['#00008b']
         end
       end
 


### PR DESCRIPTION
Adds styling to the currency buttons. Specifically focuses on adding the color to each button with a hover effect. The color of the buttons match the lines in the chart so it is clear which one you are choosing without even referencing the label.