### PR TITLE
Update Rubocop settings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,3 +8,9 @@ AllCops:
     - Rakefile
     - spec/spec_helper.rb
     - spec/rails_helper.rb
+Metrics/MethodLength:
+  Exclude:
+    - app/services/rate_getter_service.rb
+Metrics/BlockLength:
+  Exclude:
+    - spec/services/rate_getter_service_spec.rb

--- a/app/services/rate_getter_service.rb
+++ b/app/services/rate_getter_service.rb
@@ -39,7 +39,6 @@ class RateGetterService
     JSON.parse(api_request)
   end
 
-  # rubocop:disable Metrics/MethodLength
   def reorder_json_data(json_data)
     sequential_rates = json_data['rates'].sort.to_h
     sequential_rates.each do |date, rate_hash|
@@ -54,7 +53,6 @@ class RateGetterService
       end
     end
   end
-  # rubocop:enable Metrics/MethodLength
 
   def setup_series_data
     [euro_series, usd_series, aud_series].compact

--- a/spec/services/rate_getter_service_spec.rb
+++ b/spec/services/rate_getter_service_spec.rb
@@ -1,6 +1,5 @@
 require 'rails_helper'
 
-# rubocop:disable Metrics/BlockLength
 RSpec.describe RateGetterService, type: :service do
   let(:service) { RateGetterService.new('EUR,USD,AUD') }
   let(:sample_euro_data) { { '2019-01-02' => 0.2276348737 } }
@@ -145,4 +144,3 @@ RSpec.describe RateGetterService, type: :service do
     end
   end
 end
-# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
Updates the Rubocop settings to exclude the specific checks instead of manually doing it inside of the file. This keeps the file cleaner and shows all of the Rubocop exclusion in a single place.